### PR TITLE
Fix query functions

### DIFF
--- a/src/ascore/command.cc
+++ b/src/ascore/command.cc
@@ -29,6 +29,14 @@ ascore_command_status_t ascore_command_send(ascon_st *con, ascore_command_t comm
     return con->command_status;
   }
 
+  /* Reset a bunch of internals */
+  con->result.current_column= 0;
+  con->affected_rows= 0;
+  con->insert_id= 0;
+  con->server_status= 0;
+  con->warning_count= 0;
+  con->server_errno= 0;
+
   asdebug("Sending command %02X to sever", command);
   con->local_errcode= ASRET_OK;
   con->errmsg[0]= '\0';
@@ -46,7 +54,7 @@ ascore_command_status_t ascore_command_send(ascon_st *con, ascore_command_t comm
   {
     send_buffer[2].base= data;
     send_buffer[2].len= length;
-    asdebug("Sending %lld bytes with command to server", length);
+    asdebug("Sending %zd bytes with command to server", length);
     asdebug_hex(data, length);
     ret= uv_write(&con->uv_objects.write_req, con->uv_objects.stream, send_buffer, 3, on_write);
   }

--- a/src/ascore/connect.cc
+++ b/src/ascore/connect.cc
@@ -181,7 +181,7 @@ void on_resolved(uv_getaddrinfo_t *resolver, int status, struct addrinfo *res)
 
 ascore_con_status_t ascore_con_poll(ascon_st *con)
 {
-  asdebug("Connection poll");
+  //asdebug("Connection poll");
   if (con == NULL)
   {
     return ASCORE_CON_STATUS_PARAMETER_ERROR;
@@ -311,7 +311,7 @@ uv_buf_t on_alloc(uv_handle_t *client, size_t suggested_size)
   uv_buf_t buf;
   ascon_st *con= (ascon_st*) client->loop->data;
 
-  asdebug("%lld bytes requested for read buffer", suggested_size);
+  asdebug("%zd bytes requested for read buffer", suggested_size);
 
   if (con->read_buffer == NULL)
   {
@@ -321,7 +321,7 @@ uv_buf_t on_alloc(uv_handle_t *client, size_t suggested_size)
   buffer_free= ascore_buffer_get_available(con->read_buffer);
   if (buffer_free < suggested_size)
   {
-    asdebug("Enlarging buffer, free: %lld, requested: %lld", buffer_free, suggested_size);
+    asdebug("Enlarging buffer, free: %zd, requested: %zd", buffer_free, suggested_size);
     ascore_buffer_increase(con->read_buffer);
     buffer_free= ascore_buffer_get_available(con->read_buffer);
   }

--- a/src/ascore/net.cc
+++ b/src/ascore/net.cc
@@ -26,7 +26,7 @@ void ascore_send_data(ascon_st *con, char *data, size_t length)
 {
   uv_buf_t send_buffer[2];
 
-  asdebug("Sending %lld bytes to server", length);
+  asdebug("Sending %zd bytes to server", length);
   ascore_pack_int3(con->packet_header, length);
   con->packet_number++;
   con->packet_header[3]= con->packet_number;
@@ -74,7 +74,7 @@ void ascore_read_data_cb(uv_stream_t* tcp, ssize_t read_size, const uv_buf_t buf
     con->next_packet_type= ASCORE_PACKET_TYPE_NONE;
     return;
   }
-  asdebug("Got data, %lld bytes", read_size);
+  asdebug("Got data, %zd bytes", read_size);
   ascore_buffer_move_write_ptr(con->read_buffer, read_size);
   ascore_con_process_packets(con);
 }
@@ -100,7 +100,7 @@ bool ascore_con_process_packets(ascon_st *con)
 
     if ((packet_len + 4) > data_size)
     {
-      asdebug("Don't have whole packet, expected %u bytes, got %llu", packet_len, data_size - 4);
+      asdebug("Don't have whole packet, expected %u bytes, got %zu", packet_len, data_size - 4);
       return false;
     }
 

--- a/src/asql/query.cc
+++ b/src/asql/query.cc
@@ -139,7 +139,6 @@ attachsql_error_st *attachsql_query(attachsql_connect_t *con, size_t length, con
           }
           break;
       }
-      pos++;
       param++;
     }
   }

--- a/tests/asql/query.cc
+++ b/tests/asql/query.cc
@@ -26,17 +26,19 @@ int main(int argc, char *argv[])
   attachsql_connect_t *con;
   attachsql_error_st *error;
   const char *data= "SHOW PROCESSLIST";
-  attachsql_return_t ret= ATTACHSQL_RETURN_NONE;
+  const char *data2= "SELECT ? as a, '?' as b, ? as c";
+  attachsql_return_t aret= ATTACHSQL_RETURN_NONE;
   attachsql_query_row_st *row;
+  attachsql_query_parameter_st param[3];
   uint16_t columns, col;
 
   con= attachsql_connect_create("localhost", 3306, "test", "test", "", NULL);
   error= attachsql_query(con, strlen(data), data, 0, NULL);
   ASSERT_NULL_(error, "Error not NULL");
-  while(ret != ATTACHSQL_RETURN_EOF)
+  while(aret != ATTACHSQL_RETURN_EOF)
   {
-    ret= attachsql_connect_poll(con, &error);
-    if (ret == ATTACHSQL_RETURN_ROW_READY)
+    aret= attachsql_connect_poll(con, &error);
+    if (aret == ATTACHSQL_RETURN_ROW_READY)
     {
       row= attachsql_query_row_get(con, &error);
       columns= attachsql_query_column_count(con);
@@ -44,6 +46,36 @@ int main(int argc, char *argv[])
       {
         printf("Column: %d, Length: %zu, Data: %.*s ", col, row[col].length, (int)row[col].length, row[col].data);
       }
+      attachsql_query_row_next(con);
+      printf("\n");
+    }
+  }
+  attachsql_query_close(con);
+  const char *td= "test";
+  uint32_t tn= 45768;
+  param[0].type= ATTACHSQL_ESCAPE_TYPE_CHAR;
+  param[0].data= (char*)td;
+  param[0].length= strlen(td);
+  param[1].type= ATTACHSQL_ESCAPE_TYPE_CHAR_LIKE;
+  param[1].data= (char*)td;
+  param[1].length= strlen(td);
+  param[2].type= ATTACHSQL_ESCAPE_TYPE_INT;
+  param[2].data= &tn;
+  param[2].is_unsigned= true;
+  error= attachsql_query(con, strlen(data2), data2, 3, param);
+  ASSERT_NULL_(error, "Error not NULL");
+  aret= ATTACHSQL_RETURN_NONE;
+  while(aret != ATTACHSQL_RETURN_EOF)
+  {
+    aret= attachsql_connect_poll(con, &error);
+    if (aret == ATTACHSQL_RETURN_ROW_READY)
+    {
+      row= attachsql_query_row_get(con, &error);
+      columns= attachsql_query_column_count(con);
+      ASSERT_EQ_(3, columns, "Column count unexpected");
+      ASSERT_STREQL_("test", row[0].data, 4, "Bad row data");
+      ASSERT_STREQL_("test", row[1].data, 4, "Bad row data");
+      ASSERT_STREQL_("45768", row[2].data, 5, "Bad row data");
       attachsql_query_row_next(con);
       printf("\n");
     }

--- a/yatl/lite.h
+++ b/yatl/lite.h
@@ -304,6 +304,30 @@ do \
   } \
 } while (0)
 
+#define ASSERT_STREQL_(__expected_str, __actual_str, __length,...) \
+do \
+{ \
+  int ret= strncmp(__expected_str, __actual_str, __length); \
+  if (ret) { \
+    size_t ask= snprintf(0, 0, __VA_ARGS__); \
+    ask++; \
+    char *buffer= (char*)alloca(sizeof(char) * ask); \
+    ask= snprintf(buffer, ask, __VA_ARGS__); \
+    if (YATL_FULL) { \
+      FAIL("Assertion '%.*s' != '%.*s' [ %.*s ]", \
+           (int)(__length), (__expected_str), \
+           (int)(__length), (__actual_str), \
+           (int)(ask), buffer); \
+    } \
+    fprintf(stderr, "\n%s:%d: %s Assertion '%.*s' != '%.*s' [ %.*s ]\n", __FILE__, __LINE__, __PRETTY_FUNCTION__, \
+            (int)(__length), (__expected_str), \
+            (int)(__length), (__actual_str), \
+            (int)(ask), buffer); \
+    exit(EXIT_FAILURE); \
+  } \
+} while (0)
+
+
 #define ASSERT_STRNE(__expected_str, __actual_str) \
 do \
 { \


### PR DESCRIPTION
1. Query parameter processing had an off-by-one bug
2. Required internals were not reset for a second query
3. YATL couldn't handle non-NUL-terminated strings for compare
4. Wrong printf parameters used on some debugging messages

Fixes libattachsql/libattachsql#2
