### PR TITLE
Fix everything flagged by initial coverity scan

### DIFF
--- a/src/ascore/buffer.cc
+++ b/src/ascore/buffer.cc
@@ -36,6 +36,7 @@ buffer_st *ascore_buffer_create()
   buffer->buffer= (char*)malloc(ASCORE_DEFAULT_BUFFER_SIZE);
   if (buffer->buffer == NULL)
   {
+    delete buffer;
     return NULL;
   }
 

--- a/src/ascore/connect.cc
+++ b/src/ascore/connect.cc
@@ -207,15 +207,16 @@ ascore_con_status_t ascore_connect(ascon_st *con)
 {
   int ret;
 
+  if (con == NULL)
+  {
+    return ASCORE_CON_STATUS_PARAMETER_ERROR;
+  }
+
   con->uv_objects.hints.ai_family = PF_INET;
   con->uv_objects.hints.ai_socktype = SOCK_STREAM;
   con->uv_objects.hints.ai_protocol = IPPROTO_TCP;
   con->uv_objects.hints.ai_flags = 0;
 
-  if (con == NULL)
-  {
-    return ASCORE_CON_STATUS_PARAMETER_ERROR;
-  }
   if (con->status != ASCORE_CON_STATUS_NOT_CONNECTED)
   {
     return con->status;
@@ -349,6 +350,7 @@ void ascore_packet_read_handshake(ascon_st *con)
   // Server version (null-terminated string)
   buffer->buffer_read_ptr++;
   strncpy(con->server_version, buffer->buffer_read_ptr, ASCORE_MAX_SERVER_VERSION_LEN);
+  con->server_version[ASCORE_MAX_SERVER_VERSION_LEN - 1]= '\0';
   buffer->buffer_read_ptr+= strlen(con->server_version) + 1;
 
   // Thread ID
@@ -476,7 +478,7 @@ asret_t scramble_password(ascon_st *con, unsigned char *buffer)
   unsigned char stage2[SHA1_DIGEST_LENGTH];
   uint8_t it;
 
-  if (con->scramble_buffer == NULL)
+  if (con->scramble_buffer[0] == '\0')
   {
     asdebug("No scramble supplied from server");
     return ASRET_NO_SCRAMBLE;

--- a/src/ascore/net.cc
+++ b/src/ascore/net.cc
@@ -294,7 +294,7 @@ void ascore_packet_read_column(ascon_st *con)
   // Schema
   str_len= ascore_unpack_length(buffer->buffer_read_ptr, &bytes, NULL);
   buffer->buffer_read_ptr+= bytes;
-  if (str_len >= ASCORE_MAX_SCHEMA_SIZE)
+  if (str_len > ASCORE_MAX_SCHEMA_SIZE)
   {
     str_read= ASCORE_MAX_SCHEMA_SIZE - 1;
   }
@@ -309,7 +309,7 @@ void ascore_packet_read_column(ascon_st *con)
   // Table
   str_len= ascore_unpack_length(buffer->buffer_read_ptr, &bytes, NULL);
   buffer->buffer_read_ptr+= bytes;
-  if (str_len >= ASCORE_MAX_TABLE_SIZE)
+  if (str_len > ASCORE_MAX_TABLE_SIZE)
   {
     str_read= ASCORE_MAX_TABLE_SIZE -1;
   }
@@ -324,7 +324,7 @@ void ascore_packet_read_column(ascon_st *con)
   // Origin table
   str_len= ascore_unpack_length(buffer->buffer_read_ptr, &bytes, NULL);
   buffer->buffer_read_ptr+= bytes;
-  if (str_len >= ASCORE_MAX_TABLE_SIZE)
+  if (str_len > ASCORE_MAX_TABLE_SIZE)
   {
     str_read= ASCORE_MAX_TABLE_SIZE -1;
   }
@@ -339,7 +339,7 @@ void ascore_packet_read_column(ascon_st *con)
   // Column
   str_len= ascore_unpack_length(buffer->buffer_read_ptr, &bytes, NULL);
   buffer->buffer_read_ptr+= bytes;
-  if (str_len >= ASCORE_MAX_COLUMN_SIZE)
+  if (str_len > ASCORE_MAX_COLUMN_SIZE)
   {
     str_read= ASCORE_MAX_COLUMN_SIZE -1;
   }
@@ -354,7 +354,7 @@ void ascore_packet_read_column(ascon_st *con)
   // Origin column
   str_len= ascore_unpack_length(buffer->buffer_read_ptr, &bytes, NULL);
   buffer->buffer_read_ptr+= bytes;
-  if (str_len >= ASCORE_MAX_COLUMN_SIZE)
+  if (str_len > ASCORE_MAX_COLUMN_SIZE)
   {
     str_read= ASCORE_MAX_COLUMN_SIZE -1;
   }

--- a/src/ascore/pack.cc
+++ b/src/ascore/pack.cc
@@ -35,6 +35,7 @@ uint64_t ascore_unpack_length(char *buffer, uint8_t *bytes, ascore_pack_status_t
   if ((bytes == NULL) || (buffer == NULL))
   {
     *status= ASCORE_PACK_INVALID_ARGUMENT;
+    return 0;
   }
   *status= ASCORE_PACK_OK;
 

--- a/src/asql/connect.cc
+++ b/src/asql/connect.cc
@@ -48,7 +48,7 @@ attachsql_connect_t *attachsql_connect_create(const char *host, in_port_t port, 
     }
     ascore_con_destroy(con->core_con);
     attachsql_connect_destroy(con);
-    con= NULL;
+    return NULL;
   }
 
   ascore_con_set_option(con->core_con, ASCORE_CON_OPTION_POLLING, true);
@@ -233,12 +233,5 @@ attachsql_error_st *attachsql_connect(attachsql_connect_t *con)
       break;
   }
 
-  if (error != NULL)
-  {
-    return error;
-  }
-  else
-  {
-    return NULL;
-  }
+  return NULL;
 }


### PR DESCRIPTION
Coverity picked up 14 defects, this fixes 13 of them (one of them should be false due to libuv usage but I may clean it up later anyway).
