### PR TITLE
Check buffer before poll

### DIFF
--- a/src/ascore/connect.cc
+++ b/src/ascore/connect.cc
@@ -193,7 +193,11 @@ ascore_con_status_t ascore_con_poll(ascon_st *con)
   }
   if (con->options.polling)
   {
-    uv_run(con->uv_objects.loop, UV_RUN_NOWAIT);
+    // Make sure we aren't polling for somethin already in the buffer first
+    if (not ascore_con_process_packets(con))
+    {
+      uv_run(con->uv_objects.loop, UV_RUN_NOWAIT);
+    }
   }
   else
   {


### PR DESCRIPTION
Sometimes we may already have the data we are polling for in the buffer.
A common example is multi-statement result sets.  Check the buffer for
packets before trying to pull more off the network.

Fixes #21
