### PR TITLE
Compile examples and fix test cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -48,3 +48,4 @@ libattachsql-config
 examples/*
 !examples/*\.c
 !examples/*\.sql
+!examples/include.am

--- a/Makefile.am
+++ b/Makefile.am
@@ -40,6 +40,7 @@ include src/ascore/include.am
 include src/asql/include.am
 include libattachsql-1.0/include.am
 include tests/include.am
+include examples/include.am
 include rpm/include.mk
 include docs/include.am
 include yatl/include.am

--- a/docs/introduction/version_history.rst
+++ b/docs/introduction/version_history.rst
@@ -16,12 +16,17 @@ Version 0.5.0 Beta (Not yet released)
 * Add a semi-blocking mode for one connection per thread access (`Issue #89 <https://github.com/libattachsql/libattachsql/issues/89>`_)
 * Attempt to error when file descriptors are exhausted (`Issue #92 <https://github.com/libattachsql/libattachsql/issues/92>`_)
 * Add the start of troubleshooting documentation
-* Changed error struct to a hidden error type (``attachsql_error_st`` has been replaced by :c:type:`attachsql_error_t`) and added access functions (:c:func:`attachsql_error_code`, :c:func:`attachsql_error_message` and :c:func:`attachsql_error_sqlstate`).
+* Fix statement and statement_param test cases when a MySQL server is not present (`Issue #99 <https://github.com/libattachsql/libattachsql/issues/99>`_)
+* Examples are now compiled to ensure API compatibility (`Issue #97 <https://github.com/libattachsql/libattachsql/issues/97>`_)
+
+Incompatible changes
+""""""""""""""""""""
 
   .. warning::
 
-     This is an API incompatible change over 0.4.0
+     These changes are API incompatible change over 0.4.0
 
+* Changed error struct to a hidden error type (``attachsql_error_st`` has been replaced by :c:type:`attachsql_error_t`) and added access functions (:c:func:`attachsql_error_code`, :c:func:`attachsql_error_message` and :c:func:`attachsql_error_sqlstate`).
 * Changed several functions for a more consistent error handling API.  These are:
 
   * :c:func:`attachsql_connect`
@@ -43,10 +48,6 @@ Version 0.5.0 Beta (Not yet released)
   * :c:func:`attachsql_statement_set_datetime`
   * :c:func:`attachsql_statement_set_time`
   * :c:func:`attachsql_statement_row_get`
-
-  .. warning::
-
-     This is an API incompatible change over 0.4.0
 
 Version 0.4
 -----------

--- a/examples/basic_query.c
+++ b/examples/basic_query.c
@@ -20,7 +20,7 @@
 #include <stdio.h>
 #include <string.h>
 
-int main(int argc, char *argv[])
+int main(void)
 {
   attachsql_connect_t *con= NULL;
   attachsql_error_t *error= NULL;

--- a/examples/buffered_query.c
+++ b/examples/buffered_query.c
@@ -20,7 +20,7 @@
 #include <stdio.h>
 #include <string.h>
 
-int main(int argc, char *argv[])
+int main(void)
 {
   attachsql_connect_t *con= NULL;
   attachsql_error_t *error= NULL;
@@ -40,7 +40,7 @@ int main(int argc, char *argv[])
   if (error != NULL)
   {
     printf("Error occurred: %s", attachsql_error_message(error));
-    return;
+    return 1;
   }
 
   columns= attachsql_query_column_count(con);

--- a/examples/escaped_query.c
+++ b/examples/escaped_query.c
@@ -20,7 +20,7 @@
 #include <stdio.h>
 #include <string.h>
 
-int main(int argc, char *argv[])
+int main(void)
 {
   attachsql_connect_t *con= NULL;
   attachsql_error_t *error= NULL;
@@ -31,10 +31,10 @@ int main(int argc, char *argv[])
   attachsql_query_parameter_st param[2];
 
   con= attachsql_connect_create("localhost", 3306, "test", "test", "testdb", NULL);
-  char *name= "fred";
+  const char *name= "fred";
   uint32_t age= 30;
   param[0].type= ATTACHSQL_ESCAPE_TYPE_CHAR;
-  param[0].data= name;
+  param[0].data= (char*)name;
   param[0].length= strlen(name);
   param[1].type= ATTACHSQL_ESCAPE_TYPE_INT;
   param[1].data= &age;

--- a/examples/include.am
+++ b/examples/include.am
@@ -1,0 +1,21 @@
+# vim:ft=automake
+# Copyright (C) 2012 Data Differential
+# All rights reserved.
+#
+# Use and distribution licensed under the BSD license.  See
+# the COPYING file in the parent directory for full text.
+#
+# included from Top Level Makefile.am
+# All paths should be given relative to the root
+
+examples_basic_query_SOURCES= examples/basic_query.c
+examples_basic_query_LDADD= src/asql/libattachsql.la
+noinst_PROGRAMS+= examples/basic_query
+
+examples_buffered_query_SOURCES= examples/buffered_query.c
+examples_buffered_query_LDADD= src/asql/libattachsql.la
+noinst_PROGRAMS+= examples/buffered_query
+
+examples_escaped_query_SOURCES= examples/escaped_query.c
+examples_escaped_query_LDADD= src/asql/libattachsql.la
+noinst_PROGRAMS+= examples/escaped_query

--- a/tests/asql/statement.cc
+++ b/tests/asql/statement.cc
@@ -35,6 +35,14 @@ int main(int argc, char *argv[])
   while(aret != ATTACHSQL_RETURN_EOF)
   {
     aret= attachsql_connect_poll(con, &error);
+    if (error && (attachsql_error_code(error) == 2002))
+    {
+      SKIP_IF_(true, "No MYSQL server");
+    }
+    else if (error)
+    {
+      ASSERT_FALSE_(true, "Error exists: %d", attachsql_error_code(error));
+    }
   }
 
   attachsql_statement_execute(con, &error);
@@ -49,11 +57,7 @@ int main(int argc, char *argv[])
       printf("Got %d columns\n", columns);
       attachsql_query_row_next(con);
     }
-    if (error && (attachsql_error_code(error) == 2002))
-    {
-      SKIP_IF_(true, "No MYSQL server");
-    }
-    else if (error)
+    if (error)
     {
       ASSERT_FALSE_(true, "Error exists: %d", attachsql_error_code(error));
     }

--- a/tests/asql/statement_param.cc
+++ b/tests/asql/statement_param.cc
@@ -36,6 +36,14 @@ int main(int argc, char *argv[])
   while(aret != ATTACHSQL_RETURN_EOF)
   {
     aret= attachsql_connect_poll(con, &error);
+    if (error && (attachsql_error_code(error) == 2002))
+    {
+      SKIP_IF_(true, "No MYSQL server");
+    }
+    else if (error)
+    {
+      ASSERT_FALSE_(true, "Error exists: %d", attachsql_error_code(error));
+    }
   }
   attachsql_statement_set_string(con, 0, 11, data2, NULL);
   attachsql_statement_set_int(con, 1, 123456, NULL);
@@ -62,11 +70,7 @@ int main(int argc, char *argv[])
       ASSERT_STREQL_("2007-11-30 16:30:19", col_data, len, "Column 2 str conversion fail");
       attachsql_query_row_next(con);
     }
-    if (error && (attachsql_error_code(error) == 2002))
-    {
-      SKIP_IF_(true, "No MYSQL server");
-    }
-    else if (error)
+    if (error)
     {
       ASSERT_FALSE_(true, "Error exists: %d", attachsql_error_code(error));
     }


### PR DESCRIPTION
- Examples are now compiled (but not installed) to maintain API
  compatibility
- Statement test cases hung with no MySQL server due to not testing the
  initial poll loop for errors

Fixes #99 
Closes #97 
