### PR TITLE
Fix Windows Building

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -117,7 +117,7 @@ AX_PRINTF_STRERROR
 AX_PTHREAD_TIMEDJOIN_NP
 
 AX_CHECK_LIBRARY([LIBUV], [uv.h], [uv], [], [AC_MSG_ERROR(could not find libuv)])
-AX_CHECK_LIBRARY([ZLIB], [zlib.h], [z], [], [AC_MSG_WARN(could not find libuv)])
+AX_CHECK_LIBRARY([ZLIB], [zlib.h], [z], [], [AC_MSG_WARN(could not find zlib)])
 AX_CHECK_OPENSSL([ax_cv_openssl=yes
                   AC_DEFINE([HAVE_OPENSSL], [1], [Define to 1 if you have OpenSSL])
                   ], [

--- a/docs/appendix/version_history.rst
+++ b/docs/appendix/version_history.rst
@@ -24,7 +24,8 @@ Version 0.9.0 RC (Not yet Released)
   * Packet processing is now part of the event loop
   * Added example
 
-* Remove bootstrap.sh file, autoreconf should be used instead
+* Remove bootstrap.sh file, autoreconf should be used instead (`Issue #66 <https://github.com/libattachsql/libattachsql/issues/66>`_)
+* Fix MinGW compiling issues (`Issue #118 <https://github.com/libattachsql/libattachsql/issues/118>`_)
 
 Version 0.5
 -----------

--- a/docs/introduction/compiling.rst
+++ b/docs/introduction/compiling.rst
@@ -88,6 +88,12 @@ It is possible to use Fedora Linux to cross-compile using MinGW for 64bit Window
       mingw64-configure --disable-shared --enable-static
       mingw64-make
 
+With Arch Linux the MinGW sysroot to copy files to is ``/usr/x86_64-w64-mingw32/`` without the ``sys-root/mingw`` on the end and to compile::
+
+   autoreconf -fi
+   ./configure --prefix=/usr/x86_64-w64-mingw32/ --with-sysroot=/usr/x86_64-w64-mingw32/ --host=x86_64-w64-mingw32
+   make
+
 Testing
 -------
 

--- a/examples/include.am
+++ b/examples/include.am
@@ -10,22 +10,53 @@
 
 examples_basic_query_SOURCES= examples/basic_query.c
 examples_basic_query_LDADD= src/asql/libattachsql.la
+if BUILD_WIN32
+examples_basic_query_LDADD+= -lws2_32
+examples_basic_query_LDADD+= -lpsapi
+examples_basic_query_LDADD+= -liphlpapi
+examples_basic_query_LDADD+= -lstdc++
+endif
 noinst_PROGRAMS+= examples/basic_query
 
 examples_buffered_query_SOURCES= examples/buffered_query.c
 examples_buffered_query_LDADD= src/asql/libattachsql.la
+if BUILD_WIN32
+examples_buffered_query_LDADD+= -lws2_32
+examples_buffered_query_LDADD+= -lpsapi
+examples_buffered_query_LDADD+= -liphlpapi
+examples_buffered_query_LDADD+= -lstdc++
+endif
 noinst_PROGRAMS+= examples/buffered_query
 
 examples_escaped_query_SOURCES= examples/escaped_query.c
 examples_escaped_query_LDADD= src/asql/libattachsql.la
+if BUILD_WIN32
+examples_escaped_query_LDADD+= -lws2_32
+examples_escaped_query_LDADD+= -lpsapi
+examples_escaped_query_LDADD+= -liphlpapi
+examples_escaped_query_LDADD+= -lstdc++
+endif
 noinst_PROGRAMS+= examples/escaped_query
 
 examples_prepared_statement_SOURCES= examples/prepared_statement.c
 examples_prepared_statement_LDADD= src/asql/libattachsql.la
+if BUILD_WIN32
+examples_prepared_statement_LDADD+= -lws2_32
+examples_prepared_statement_LDADD+= -lpsapi
+examples_prepared_statement_LDADD+= -liphlpapi
+examples_prepared_statement_LDADD+= -lstdc++
+endif
 noinst_PROGRAMS+= examples/prepared_statement
 
 examples_group_query_SOURCES= examples/group_query.c
 examples_group_query_LDADD= src/asql/libattachsql.la
+if BUILD_WIN32
+examples_group_query_LDADD+= -lws2_32
+examples_group_query_LDADD+= -lpsapi
+examples_group_query_LDADD+= -liphlpapi
+examples_group_query_CFLAGS= -D__USE_MINGW_ANSI_STDIO
+examples_group_query_LDADD+= -lstdc++
+endif
 noinst_PROGRAMS+= examples/group_query
 
 

--- a/m4/ax_check_openssl.m4
+++ b/m4/ax_check_openssl.m4
@@ -32,7 +32,7 @@
 #   and this notice are preserved. This file is offered as-is, without any
 #   warranty.
 
-#serial 8
+#serial 9
 
 AU_ALIAS([CHECK_SSL], [AX_CHECK_OPENSSL])
 AC_DEFUN([AX_CHECK_OPENSSL], [
@@ -111,9 +111,11 @@ AC_DEFUN([AX_CHECK_OPENSSL], [
             AC_MSG_RESULT([yes])
             $1
         ], [
+            OPENSSL_LIBS=""
             AC_MSG_RESULT([no])
             $2
         ])
+
     CPPFLAGS="$save_CPPFLAGS"
     LDFLAGS="$save_LDFLAGS"
     LIBS="$save_LIBS"

--- a/tests/asql/include.am
+++ b/tests/asql/include.am
@@ -10,6 +10,11 @@
 
 t_asql_version_SOURCES= tests/asql/version.cc
 t_asql_version_LDADD= src/asql/libattachsql.la
+if BUILD_WIN32
+t_asql_version_LDADD+= -lws2_32
+t_asql_version_LDADD+= -lpsapi
+t_asql_version_LDADD+= -liphlpapi
+endif
 check_PROGRAMS+= t/asql/version
 noinst_PROGRAMS+= t/asql/version
 


### PR DESCRIPTION
- Make examples and tests link correctly
- Fix OpenSSL detection failure when cross-compiling

Fixes #118 
