### PR TITLE
Remove uneeded libuv calls

### DIFF
--- a/src/ascore/command.cc
+++ b/src/ascore/command.cc
@@ -32,7 +32,6 @@ ascore_command_status_t ascore_command_send_compressed(ascon_st *con, ascore_com
     {
       con->next_packet_type= ASCORE_PACKET_TYPE_RESPONSE;
     }
-    uv_read_start(con->uv_objects.stream, on_alloc, ascore_read_data_cb);
     con->command_status= ASCORE_COMMAND_STATUS_SEND;
     con->status= ASCORE_CON_STATUS_BUSY;
     ascore_run_uv_loop(con);
@@ -138,10 +137,6 @@ ascore_command_status_t ascore_command_send(ascon_st *con, ascore_command_t comm
   {
     con->next_packet_type= ASCORE_PACKET_TYPE_RESPONSE;
   }
-  if ((command != ASCORE_COMMAND_STMT_RESET) && (command != ASCORE_COMMAND_STMT_CLOSE))
-  {
-    uv_read_start(con->uv_objects.stream, on_alloc, ascore_read_data_cb);
-  }
   con->command_status= ASCORE_COMMAND_STATUS_SEND;
   con->status= ASCORE_CON_STATUS_BUSY;
   ascore_run_uv_loop(con);
@@ -173,7 +168,6 @@ bool ascore_command_next_result(ascon_st *con)
     con->warning_count= 0;
     con->server_errno= 0;
     con->next_packet_type= ASCORE_PACKET_TYPE_RESPONSE;
-    uv_read_start(con->uv_objects.stream, on_alloc, ascore_read_data_cb);
     con->command_status= ASCORE_COMMAND_STATUS_READ_RESPONSE;
     con->status= ASCORE_CON_STATUS_BUSY;
     ascore_run_uv_loop(con);

--- a/src/ascore/connect.cc
+++ b/src/ascore/connect.cc
@@ -429,10 +429,6 @@ void ascore_handshake_response(ascon_st *con)
 
   asdebug("Sending handshake response");
   buffer_ptr= (unsigned char*)con->write_buffer;
-  if (con->next_packet_type != ASCORE_PACKET_TYPE_HANDSHAKE_SSL)
-  {
-    uv_read_start(con->uv_objects.stream, on_alloc, ascore_read_data_cb);
-  }
 
   capabilities= con->server_capabilities & ASCORE_CAPABILITY_CLIENT;
   capabilities|= ASCORE_CAPABILITY_MULTI_RESULTS;

--- a/src/ascore/net.cc
+++ b/src/ascore/net.cc
@@ -630,14 +630,12 @@ void ascore_packet_read_row(ascon_st *con)
   con->next_packet_type= ASCORE_PACKET_TYPE_NONE;
   con->command_status= ASCORE_COMMAND_STATUS_ROW_IN_BUFFER;
   con->status= ASCORE_CON_STATUS_IDLE;
-  uv_read_stop(con->uv_objects.stream);
 }
 
 void ascore_packet_read_end(ascon_st *con)
 {
   asdebug("Packet end");
 
-  uv_read_stop(con->uv_objects.stream);
   ascore_buffer_packet_read_end(con->read_buffer);
 }
 


### PR DESCRIPTION
read_stop only stops looking for read events whilst polling a TCP
connection.  It does not stop the polling so it is effectively useless.
Therefore there is now only one read start and no read stop.

Closes #140 
