### PR TITLE
Optimise prepare response

### DIFF
--- a/src/ascore/net.cc
+++ b/src/ascore/net.cc
@@ -669,10 +669,6 @@ void ascore_packet_read_prepare_response(ascon_st *con)
       con->stmt->params= new (std::nothrow) column_t[con->stmt->param_count];
       con->stmt->param_data= new (std::nothrow) ascore_stmt_param_st[con->stmt->param_count];
     }
-    if (con->stmt->column_count)
-    {
-      con->stmt->columns= new (std::nothrow) column_t[con->stmt->column_count];
-    }
     if (con->stmt->param_count > 0)
     {
       ascore_packet_queue_push(con, ASCORE_PACKET_TYPE_PREPARE_PARAMETER);
@@ -836,10 +832,9 @@ void ascore_packet_read_prepare_parameter(ascon_st *con)
 
 void ascore_packet_read_prepare_column(ascon_st *con)
 {
-  asdebug("Prepare column packet callback");
-  column_t *column;
-  column= &con->stmt->columns[con->stmt->current_column];
-  ascore_packet_get_column(con, column);
+  /* Skipping these packets as they are useless */
+  asdebug("Prepare column packet callback (skipped)");
+  ascore_buffer_packet_read_end(con->read_buffer);
   con->stmt->current_column++;
   if (con->stmt->current_column == con->stmt->column_count)
   {
@@ -868,7 +863,6 @@ void ascore_packet_read_column(ascon_st *con)
     ascore_packet_queue_push(con, ASCORE_PACKET_TYPE_COLUMN);
   }
 }
-
 
 void ascore_packet_get_column(ascon_st *con, column_t *column)
 {

--- a/src/ascore/statement.cc
+++ b/src/ascore/statement.cc
@@ -250,10 +250,6 @@ void ascore_stmt_destroy(ascore_stmt_st *stmt)
   {
     return;
   }
-  if (stmt->column_count > 0)
-  {
-    delete[] stmt->columns;
-  }
 
   if (stmt->param_count > 0)
   {

--- a/src/ascore/structs.h
+++ b/src/ascore/structs.h
@@ -135,7 +135,6 @@ struct ascore_stmt_st
   ascon_st *con;
   uint32_t id;
   uint16_t column_count;
-  column_t *columns;
   uint16_t current_column;
   uint16_t param_count;
   column_t *params;
@@ -150,7 +149,6 @@ struct ascore_stmt_st
     con(NULL),
     id(0),
     column_count(0),
-    columns(NULL),
     current_column(0),
     param_count(0),
     params(NULL),


### PR DESCRIPTION
The column packets during prepare are junk, skipping those packets
completely instead of trying to store them.

Closes #166 