### PR TITLE
Add bindep.txt file

### DIFF
--- a/bindep.txt
+++ b/bindep.txt
@@ -1,0 +1,12 @@
+build-essential [platform:dpkg]
+libuv-devel [platform:rpm build]
+libuv1-dev [platform:dpkg build]
+zlib-devel [platform:rpm build]
+zlib1g-dev [platform:dpkg build]
+openssl-devel [platform:rpm build]
+libssl-dev [platform:dpkg build]
+libuv [platform:rpm]
+libuv1 [platform:dpkg]
+zlib [platform:rpm]
+zlib1g [platform:dpkg]
+openssl


### PR DESCRIPTION
bindep is a tool that allows expressing what the distro-package
requirements are for a source repository in human readable and machine
understandable format. With the file in place, one can see what's
missing for installation with:

  bindep -b

It also supports labelling depends, so in this case:

  bindep -b build

will show things needed both for install (unlabelled) and for build. A
quick way to make sure everything is set is:

  sudo apt-get install $(bindep -b build)

or

  sudo dnf install $(bindep -b build)

Assuming the machine in question has pip installed, the following will
install bindep globally:

  sudo pip install bindep

Or, alternately, if ~/.local/bin is in the user's PATH:

  pip install --user bindep

Some CI systems, such as zuul, have facilities to use bindep.txt files
to know what dependencies need to be installed before doing things.

It's worth noting that bindep does not attempt to provide any package
mapping, which is a choice that allows it to be a dead-simple package
listing tool.